### PR TITLE
Support different architectures

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,5 @@
 name: Setup OpenSearch
+description: "It puts the OpenSearch on the Runner."
 inputs:
   opensearch-version:
     description: The OpenSearch version to download (if necessary) and use

--- a/index.js
+++ b/index.js
@@ -88,8 +88,10 @@ function download() {
   }
   if (isWindows()) {
     // fix for: cross-device link not permitted
+    run('mkdir', opensearchHome);
     run('mv', `opensearch-${opensearchVersion}`, opensearchHome)
   } else {
+    run('mkdir', '-p', opensearchHome);
     fs.renameSync(`opensearch-${opensearchVersion}`, opensearchHome);
   }
 }

--- a/index.js
+++ b/index.js
@@ -65,11 +65,11 @@ function getUrl() {
   if (process.platform == 'darwin') {
     // TODO use Mac build when available
     // https://github.com/opensearch-project/opensearch-build/issues/38
-    url = `https://artifacts.opensearch.org/releases/bundle/opensearch/${opensearchVersion}/opensearch-${opensearchVersion}-linux-x64.tar.gz`;
+    url = `https://artifacts.opensearch.org/releases/bundle/opensearch/${opensearchVersion}/opensearch-${opensearchVersion}-linux-${process.arch}.tar.gz`;
   } else if (isWindows()) {
-    url = `https://artifacts.opensearch.org/releases/bundle/opensearch/${opensearchVersion}/opensearch-${opensearchVersion}-windows-x64.zip`;
+    url = `https://artifacts.opensearch.org/releases/bundle/opensearch/${opensearchVersion}/opensearch-${opensearchVersion}-windows-${process.arch}.zip`;
   } else {
-    url = `https://artifacts.opensearch.org/releases/bundle/opensearch/${opensearchVersion}/opensearch-${opensearchVersion}-linux-x64.tar.gz`;
+    url = `https://artifacts.opensearch.org/releases/bundle/opensearch/${opensearchVersion}/opensearch-${opensearchVersion}-linux-${process.arch}.tar.gz`;
   }
   return url;
 }
@@ -175,7 +175,7 @@ function waitForReady() {
 
 const opensearchVersion = getVersion();
 const cacheDir = path.join(os.homedir(), 'opensearch');
-const opensearchHome = path.join(cacheDir, opensearchVersion);
+const opensearchHome = path.join(cacheDir, opensearchVersion, process.arch);
 
 // java compatibility
 // https://opensearch.org/docs/latest/opensearch/install/compatibility/


### PR DESCRIPTION
Heyo,

First thanks for writing this action, helped me immensely for some combo unit/integration testing I needed to do.

Thing is, we use self-hosted runners in AWS and most of them run graviton, thus I need to be able to install the arm64 version of OpenSearch.

I'm not amazing at JS, and I'm sure there are some possible improvements to be made, but it worked well enough for us, figure it might work for others.